### PR TITLE
build: Trigger a patch release on more commit types

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,16 @@
     "hooks": {
       "pre-push": "npm test"
     }
+  },
+  "release": {
+    "analyzeCommits": {
+      "preset": "angular",
+      "releaseRules": [
+        {"type": "docs", "scope": "README", "release": "patch"},
+        {"type": "build", "release": "patch"},
+        {"type": "chore", "release": "patch"},
+        {"type": "refactor", "release": "patch"}
+      ]
+    }
   }
 }


### PR DESCRIPTION
Added the following commit types for patch releases: build, chore, refactor, docs (if scope is
README).