### PR TITLE
fix(Header): Spread toggle props before adding disabled prop when using getButtonToggleProps

### DIFF
--- a/src/Accordion/Header.tsx
+++ b/src/Accordion/Header.tsx
@@ -103,8 +103,8 @@ const Header: SFC<Props> = ({ children, headingLevel, disabled }) => (
             },
             getButtonToggleProps: (props = {}) => {
               return {
-                disabled: disabled == null ? undefined : disabled,
                 ...getToggleProps(props),
+                disabled: disabled == null ? undefined : disabled,
               };
             },
           });

--- a/tests/Accordion.spec.tsx
+++ b/tests/Accordion.spec.tsx
@@ -736,7 +736,30 @@ describe('Accordion', () => {
 
         const header = getByTestId('header');
 
-        expect(header.hasAttribute('disabled')).toBe(true);
+        expect(header.getAttribute('disabled')).toEqual('');
+      });
+
+      it('cannot apply disabled property without header disabled prop', () => {
+        const { getByTestId } = render(
+          <TestAccordion>
+            <TestSection>
+              <Header>
+                {({ getButtonToggleProps }) => (
+                  <div
+                    {...getButtonToggleProps({
+                      'data-testid': 'header',
+                      disabled: true,
+                    })}
+                  />
+                )}
+              </Header>
+            </TestSection>
+          </TestAccordion>,
+        );
+
+        const header = getByTestId('header');
+
+        expect(header.hasAttribute('disabled')).toBe(false);
       });
 
       it('can be called without arguments', () => {


### PR DESCRIPTION
It was possible to set the disabled prop on the \<Header /> and then pass a different disabled prop
to getButtonToggleProps() leading to an inconsistency. Now disabled can only be applied if it's set
on the \<Header />.

## Checklist

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A
      <!-- this is optional, see the contributing guidelines for instructions -->

