### PR TITLE
fix: Added initialiseSsr function so that when using SSR the DOM will match client hydration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It is purposefully missing the ability for a section to be auto collapsed on exp
   - [\<Section />](#section-)
   - [\<Header />](#header-)
   - [\<Panel />](#panel-)
+  - [initialiseForSsr](#initialiseforssr)
 - [Design decisions](#design-decisions)
 - [Technical decisions](#technical-decisions)
 - [Contributors](#contributors)
@@ -138,6 +139,19 @@ import Accordion, { Section, Header, Panel } from './Accordion';
     </Panel>
   </Section>
 </Accordion>
+```
+
+### Server Sider Rendering (SSR)
+
+An additional `initialiseForSsr` function is required when using SSR so that the DOM matches when using client hydration:
+
+```jsx
+import { renderToString } from 'react-dom/server';
+import { initialiseForSsr } from 'react-aria-accordion';
+
+initialiseForSsr();
+renderToString(<App />);
+
 ```
 
 ## Using \<Header /> correctly
@@ -260,6 +274,12 @@ This is called with an object.
 |-----------------|---------------------------|---------------------------------------------------------------|
 | `getPanelProps` | `function(props: object)` | Returns the props you should apply to the element you render. |
 | `expanded`      | `boolean`                 | The expanded state of the section.                            |
+
+### initialiseForSsr
+
+> `function()`
+
+See [Server Side Rendering (SSR)](#server-sider-rendering-ssr) for more details.
 
 ## Design decisions
 

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -50,7 +50,9 @@ type State = {
   }>;
 };
 
-let accordionId = 1;
+let accordionId: number;
+
+initialiseForSsr();
 
 class Accordion extends Component<Props, State> {
   public state: State = {
@@ -182,3 +184,7 @@ class Accordion extends Component<Props, State> {
 }
 
 export default Accordion;
+
+export function initialiseForSsr() {
+  accordionId = 1;
+}

--- a/src/Accordion/index.ts
+++ b/src/Accordion/index.ts
@@ -1,4 +1,4 @@
-export { default } from './Accordion';
+export { default, initialiseForSsr } from './Accordion';
 export { default as Section } from './Section';
 export { default as Header } from './Header';
 export { default as Panel } from './Panel';

--- a/tests/Accordion.spec.tsx
+++ b/tests/Accordion.spec.tsx
@@ -1,7 +1,12 @@
 import React, { Component, ReactNode, SFC } from 'react';
 import { cleanup, fireEvent, render } from 'react-testing-library';
 
-import Accordion, { Header, Panel, Section } from '../src/Accordion';
+import Accordion, {
+  Header,
+  initialiseForSsr,
+  Panel,
+  Section,
+} from '../src/Accordion';
 
 type TestAccordionProps = {
   accordionProps?: object;
@@ -947,6 +952,51 @@ describe('Accordion', () => {
       expect(header.getAttribute('aria-controls')).toEqual(
         panel.getAttribute('id'),
       );
+    });
+  });
+
+  describe('initaliseForSsr', () => {
+    it('resets the accordionId (so that the DOM matches when hydrating)', () => {
+      let header;
+      let typeId;
+
+      render(
+        <TestAccordion>
+          <TestSection>
+            <TestHeader />
+          </TestSection>
+        </TestAccordion>,
+      );
+
+      cleanup();
+
+      const { getByTestId } = render(
+        <TestAccordion>
+          <TestSection>
+            <TestHeader data-testid="header" />
+          </TestSection>
+        </TestAccordion>,
+      );
+
+      header = getByTestId('header');
+      typeId = header.getAttribute('data-accordion-id-type');
+      expect(typeId).not.toContain('accordion-1');
+
+      cleanup();
+
+      initialiseForSsr();
+
+      const { getByTestId: getByTestId2 } = render(
+        <TestAccordion>
+          <TestSection>
+            <TestHeader data-testid="header" />
+          </TestSection>
+        </TestAccordion>,
+      );
+
+      header = getByTestId('header');
+      typeId = header.getAttribute('data-accordion-id-type');
+      expect(typeId).toContain('accordion-1');
     });
   });
 });


### PR DESCRIPTION
## What

fix #7

## How

`initialiseForSsr` function now available

## Checklist

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
- [ ] Added myself to contributors table N/A
